### PR TITLE
Update readme to exclude package folders

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,5 @@
 Please complete all of the following exercises.  In the email from BenchPrep's recruiting team that directed you to this Github exercise, there is a link which you should use to upload your completed project.
-Please do not include any personal identifying information (PII) or the `.git` folder.  Incomplete submissions will not be reviewed.
+Please do not include any personal identifying information (PII), the `.git` folder, or any package folders (`node_modules`).  Incomplete submissions will not be reviewed.
 
 If you have any questions, please email your hiring facilitator.
 


### PR DESCRIPTION
A recent candidate submission included `node_modules`, which caused an extremely long unzip time. Given we would have the `package-lock.json` from the submission, there's no need to include it.

Open to phrasing this differently if necessary.